### PR TITLE
Migrate from TestRestTemplate to RestTestClient

### DIFF
--- a/eux-journal-webapp/src/test/kotlin/no/nav/eux/journal/webapp/AbstractOppgaverApiImplTest.kt
+++ b/eux-journal-webapp/src/test/kotlin/no/nav/eux/journal/webapp/AbstractOppgaverApiImplTest.kt
@@ -1,20 +1,17 @@
 package no.nav.eux.journal.webapp
 
 import no.nav.eux.journal.Application
-import no.nav.eux.journal.webapp.common.httpEntity
-import no.nav.eux.journal.webapp.common.voidHttpEntity
 import no.nav.eux.journal.webapp.mock.RequestBodies
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
 import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.resttestclient.TestRestTemplate
-import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.http.HttpEntity
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.jdbc.JdbcTestUtils
+import org.springframework.test.web.servlet.client.RestTestClient
 
 @SpringBootTest(
     classes = [Application::class],
@@ -22,14 +19,14 @@ import org.springframework.test.jdbc.JdbcTestUtils
 )
 @ActiveProfiles("test")
 @EnableMockOAuth2Server
-@AutoConfigureTestRestTemplate
+@AutoConfigureRestTestClient
 abstract class AbstractOppgaverApiImplTest {
 
     @Autowired
     lateinit var mockOAuth2Server: MockOAuth2Server
 
     @Autowired
-    lateinit var restTemplate: TestRestTemplate
+    lateinit var restTestClient: RestTestClient
 
     @Autowired
     lateinit var jdbcTemplate: JdbcTemplate
@@ -43,9 +40,4 @@ abstract class AbstractOppgaverApiImplTest {
             jdbcTemplate,
         )
     }
-
-    val <T: Any> T.httpEntity: HttpEntity<T>
-        get() = httpEntity(mockOAuth2Server)
-
-    fun httpEntity() = voidHttpEntity(mockOAuth2Server)
 }

--- a/eux-journal-webapp/src/test/kotlin/no/nav/eux/journal/webapp/JournalposterTest.kt
+++ b/eux-journal-webapp/src/test/kotlin/no/nav/eux/journal/webapp/JournalposterTest.kt
@@ -1,24 +1,24 @@
 package no.nav.eux.journal.webapp
 
 import no.nav.eux.journal.webapp.common.settStatusAvbrytUrl
+import no.nav.eux.journal.webapp.common.token
 import no.nav.eux.journal.webapp.dataset.testModelSettStatusAvbrytRequest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.springframework.boot.resttestclient.postForEntity
 
 class JournalposterTest : AbstractOppgaverApiImplTest() {
 
     @Test
     fun `POST settStatusAvbryt - 204`() {
-        val createResponse = restTemplate
-            .postForEntity<String>(
-                settStatusAvbrytUrl,
-                testModelSettStatusAvbrytRequest.httpEntity,
-                "1444520"
-            )
+        restTestClient
+            .post()
+            .uri(settStatusAvbrytUrl, "1444520")
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .body(testModelSettStatusAvbrytRequest)
+            .exchange()
+            .expectStatus().isEqualTo(204)
         println("Følgende requests ble utført:")
         requestBodies.forEach { println("Path: ${it.key}, body: ${it.value}") }
-        assertThat(createResponse.statusCode.value()).isEqualTo(204)
         assertThat(requestBodies["/rest/journalpostapi/v1/journalpost/453802638/feilregistrer/settStatusAvbryt"])
             .isNotNull()
     }

--- a/eux-journal-webapp/src/test/kotlin/no/nav/eux/journal/webapp/RinasakerTest.kt
+++ b/eux-journal-webapp/src/test/kotlin/no/nav/eux/journal/webapp/RinasakerTest.kt
@@ -1,23 +1,22 @@
 package no.nav.eux.journal.webapp
 
 import no.nav.eux.journal.webapp.common.journalposterFeilregistrerUrl
+import no.nav.eux.journal.webapp.common.token
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.springframework.boot.resttestclient.postForEntity
 
 class RinasakerTest : AbstractOppgaverApiImplTest() {
 
     @Test
     fun `POST feilregistrer - ok - 200`() {
-        val createResponse = restTemplate
-            .postForEntity<String>(
-                journalposterFeilregistrerUrl,
-                httpEntity(),
-                "1444520"
-            )
+        restTestClient
+            .post()
+            .uri(journalposterFeilregistrerUrl, "1444520")
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .exchange()
+            .expectStatus().isEqualTo(200)
         println("Følgende requests ble utført:")
         requestBodies.forEach { println("Path: ${it.key}, body: ${it.value}") }
-        assertThat(createResponse.statusCode.value()).isEqualTo(200)
         assertThat(requestBodies["/rest/journalpostapi/v1/journalpost/453802638/feilregistrer/settStatusAvbryt"])
             .isNotNull()
         assertThat(requestBodies["/api/v1/oppgaver/tildelEnhetsnr"])

--- a/eux-journal-webapp/src/test/kotlin/no/nav/eux/journal/webapp/common/HttpEntity.kt
+++ b/eux-journal-webapp/src/test/kotlin/no/nav/eux/journal/webapp/common/HttpEntity.kt
@@ -3,23 +3,6 @@ package no.nav.eux.journal.webapp.common
 import com.nimbusds.jose.JOSEObjectType
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
-import org.springframework.http.HttpEntity
-import org.springframework.http.HttpHeaders
-import org.springframework.http.MediaType
-
-fun <T: Any> T.httpEntity(mockOAuth2Server: MockOAuth2Server) =
-    HttpEntity<T>(this, mockOAuth2Server.httpHeaders)
-
-fun voidHttpEntity(mockOAuth2Server: MockOAuth2Server) =
-    HttpEntity<Void>(mockOAuth2Server.httpHeaders)
-
-val MockOAuth2Server.httpHeaders: HttpHeaders
-    get() {
-        val headers = HttpHeaders()
-        headers.contentType = MediaType.APPLICATION_JSON
-        headers.set("Authorization", "Bearer ${this.token}")
-        return headers
-    }
 
 val MockOAuth2Server.token: String
     get() = this


### PR DESCRIPTION
Replace TestRestTemplate with Spring Framework 7 RestTestClient for test HTTP calls.