### PR TITLE
chore(deps): bump Tomcat to 11.0.21 and switch to Chainguard base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM gcr.io/distroless/java25
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 ENV TZ="Europe/Oslo"
 COPY eux-journal-webapp/target/eux-journal.jar /app.jar
+ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0"
 ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <maven.compiler.source>25</maven.compiler.source>
         <maven.compiler.target>25</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <tomcat.version>11.0.21</tomcat.version>
     </properties>
 
     <scm>
@@ -35,5 +36,25 @@
         <developerConnection>scm:git:https://github.com/navikt/eux-journal.git</developerConnection>
         <url>https://github.com/navikt/eux-journal.git</url>
     </scm>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>${tomcat.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
 </project>


### PR DESCRIPTION
## Summary
- pin embedded Tomcat dependencies to `11.0.21` in the root `pom.xml`
- switch the container base image from Distroless to the Chainguard JRE 25 image
- add `JAVA_OPTS` for container-aware JVM memory configuration
## Testing
- not run locally as part of PR creation
