### PR TITLE
Migrer openapi-generator til Jackson 3 og Spring Boot 4

### DIFF
--- a/eux-journal-openapi/pom.xml
+++ b/eux-journal-openapi/pom.xml
@@ -43,7 +43,7 @@
             <plugin>
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>
-                <version>7.17.0</version>
+                <version>7.21.0</version>
                 <executions>
                     <execution>
                         <id>openapi-spring</id>
@@ -59,9 +59,8 @@
                             <configOptions>
                                 <sourceFolder>src/gen/java/main</sourceFolder>
                                 <interfaceOnly>true</interfaceOnly>
-                                <serializableModel>true</serializableModel>
-                                <useSpringBoot3>true</useSpringBoot3>
-                                <addCompileSourceRoot>true</addCompileSourceRoot>
+                                <useSpringBoot4>true</useSpringBoot4>
+                                <useJackson3>true</useJackson3>
                                 <useTags>true</useTags>
                                 <enumPropertyNaming>UPPERCASE</enumPropertyNaming>
                             </configOptions>

--- a/eux-journal-webapp/pom.xml
+++ b/eux-journal-webapp/pom.xml
@@ -30,10 +30,6 @@
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-jackson2</artifactId>
-        </dependency>
 
         <!-- Kotlin -->
         <dependency>
@@ -67,7 +63,7 @@
             <artifactId>postgresql</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.module</groupId>
+            <groupId>tools.jackson.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
         </dependency>
         <dependency>

--- a/eux-journal-webapp/src/test/kotlin/no/nav/eux/journal/webapp/mock/MockResponsesEuxOppgave.kt
+++ b/eux-journal-webapp/src/test/kotlin/no/nav/eux/journal/webapp/mock/MockResponsesEuxOppgave.kt
@@ -1,6 +1,6 @@
 package no.nav.eux.journal.webapp.mock
 
-import com.fasterxml.jackson.databind.ObjectMapper
+import tools.jackson.databind.ObjectMapper
 import okhttp3.mockwebserver.MockResponse
 
 fun tildelEnhetsnrResponse(body: String): MockResponse {


### PR DESCRIPTION
- Bump openapi-generator-maven-plugin 7.17.0 -> 7.21.0
- Aktivere useSpringBoot4=true og useJackson3=true
- Fjerne useSpringBoot3, serializableModel og addCompileSourceRoot fra plugin-config
- Fjerne spring-boot-jackson2 kompat-modul fra webapp
- Bytte jackson-module-kotlin til tools.jackson.module-koordinaten
- Migrere ObjectMapper-import i MockResponsesEuxOppgave til tools.jackson.databind

Closes #11

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
