### PR TITLE
Bump parent-pom from 2.0.9 to 2.0.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>no.nav.eux</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>2.0.9</version>
+        <version>2.0.10</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
Bumps \`no.nav.eux:parent-pom\` from 2.0.9 to 2.0.10.